### PR TITLE
Add HDR support and make gdctl path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This little Kodi addon brings the ability for automatic refresh rate switching under Gnome Wayland.  
 The addon uses GNOME Display Controller (gdctl) to automatically switch the display refresh rate, when a playback starts and stop.
 
+## Requirements
+- You need to be running GNOME on Wayland
+- Your GNOME version needs to have the gdctl command, this should be the case for GNOME 48 and newer.
 
 ## How to use
 1. Download the .zip from the release page and install it. (Follow this guide, if you don't know how to install an addon in Kodi: https://kodi.wiki/view/Archive:Install_add-ons_from_zip_files)
@@ -18,6 +21,16 @@ Examples: `HDMI-0`, `DP-0` or `HDMI-1`
 Examples: `1920x1080` or `3840x2160`
 - **Default Refresh Rate**: Your default refresh rate.  
 Examples: `50`,`60` or `120`
+- **Switch to HDR mode for HDR content**: Enable this if your screen supports HDR and you want to enable HDR when playing HDR content (if your screen supports HDR, there should be an HDR toggle in your GNOME display settings). This toggle adds "--color-mode bt2100" to the gdctl command whenever HDR content is played.
+- **Path to the gdctl binary**: This defaults to just "gdctl". If the gdctl command is not in a standard location or in your PATH variable, you can specify the full path here.
+Example when using the flatpak version of Kodi: `/run/host/bin/gdctl` (Make sure to grant the host-os permissions to the flatpak, see below)
 - **gdctl string**: If you're using multiple screens, gdctl needs some more parameters.  
 Example: `--logical-monitor --monitor=HDMI-0 --right-of DP-0`  
-More infos about it: https://man.archlinux.org/man/gdctl.1.en  
+More infos about it: https://man.archlinux.org/man/gdctl.1.en
+
+## Kodi via Flatpak info
+When using a flatpak version of Kodi, you need to do two things to make this addon work:
+- set up the Path to the gdctl binary in the addon configuration
+- Enable host-os (or greater) permissions for the tv.kodi.Kodi flatpak.
+Enabling the permissions for the kodi flatpak can be done in a number of ways. The easiest is to use "Flatseal", a graphics application specifically designed for this. Install it via flathub or command line ( flatpak install com.github.tchx84.Flatseal ), launch it, select Kodi on the left, and toggle the 2nd item (filesystem=host-os) in the "Filesystem section".
+Alternatively you can grant the permissions via command line: `flatpak --user override tv.kodi.Kodi --filesystem=host-os` if your Kodi flatpak was installed in user space (find out using the `flatpak list` command), or `sudo flatpak override tv.kodi.Kodi --filesystem=host-os` for a system-wide installed Kodi flatpak.

--- a/script.wayland.rrswitcher/resources/language/resource.language.en_gb/strings.po
+++ b/script.wayland.rrswitcher/resources/language/resource.language.en_gb/strings.po
@@ -38,3 +38,11 @@ msgstr "Primary Screen?"
 msgctxt "#90007"
 msgid "Settings for the screen running Kodi"
 msgstr "Settings for the screen running Kodi"
+
+msgctxt "#90008"
+msgid "Path to the gdctl binary"
+msgstr "Path to the gdctl binary"
+
+msgctxt "#90009"
+msgid "Switch to HDR mode for HDR content"
+msgstr "Switch to HDR mode for HDR content"

--- a/script.wayland.rrswitcher/resources/settings.xml
+++ b/script.wayland.rrswitcher/resources/settings.xml
@@ -37,6 +37,23 @@
                         <heading>90001</heading>
                     </control>
                 </setting>
+                <setting id="EnableHDR" type="boolean" label="90009" help="">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle">
+                        <heading>90009</heading>
+                    </control>
+                </setting>
+                <setting id="GdctlPath" type="string" label="90008" help="">
+                    <level>0</level>
+                    <default>gdctl</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>90008</heading>
+                    </control>
+                </setting>
 			</group>
             <group id="2" label="90004">
                 <setting id="AdditionalConfig" type="string" label="90005" help="">

--- a/script.wayland.rrswitcher/rrSwitcher_config.py
+++ b/script.wayland.rrswitcher/rrSwitcher_config.py
@@ -7,7 +7,8 @@ defaultRefreshRate = 60.0
 currentRefreshRate = 0.0
 isPrimaryMonitor = True
 additionalConfig = ""
-
+gdctlPath = 'gdctl'
+enableHDR = False
 
 def getCurrentRefreshRate():
     global currentRefreshRate
@@ -18,7 +19,7 @@ def getDefaultRefreshRate():
     return "{:.3f}".format(defaultRefreshRate)
 
 def initSettings():
-    global defaultRefreshRate, defaultResolution, defautlMonitorName, isPrimaryMonitor, additionalConfig
+    global defaultRefreshRate, defaultResolution, defautlMonitorName, isPrimaryMonitor, additionalConfig, enableHDR, gdctlPath
     addonSettings = xbmcaddon.Addon('script.wayland.rrswitcher').getSettings()
     try:
         defautlMonitorName = addonSettings.getString('MonitorName')
@@ -40,5 +41,13 @@ def initSettings():
         additionalConfig = addonSettings.getString('AdditionalConfig')
     except:
         xbmc.log("[RRSwitcher]: Error while reading setting AdditionalConfig, using default value", level=xbmc.LOGWARNING)
+    try:
+        gdctlPath = addonSettings.getString('GdctlPath')
+    except:
+        xbmc.log("[RRSwitcher]: Error while reading setting GdctlPath, using default value", level=xbmc.LOGWARNING)
+    try:
+        enableHDR = addonSettings.getBool('EnableHDR')
+    except:
+        xbmc.log("[RRSwitcher]: Error while reading setting EnableHDR, using default value", level=xbmc.LOGWARNING)
     
     xbmc.log("[RRSwitcher]: Config updated" , level=xbmc.LOGINFO)

--- a/script.wayland.rrswitcher/rrSwitcher_player.py
+++ b/script.wayland.rrswitcher/rrSwitcher_player.py
@@ -9,11 +9,17 @@ class rrsPlayer(xbmc.Player):
 
     def onAVStartedAV(self):
         xbmc.log("[RRSwitcher]: Playback started" , level=xbmc.LOGINFO)
-        self.changeRefreshRate(xbmc.getInfoLabel('Player.Process(VideoFps)'))
+        hdrType = xbmc.getInfoLabel('VideoPlayer.HdrType')
+        if hdrType:
+            xbmc.log("[RRSwitcher]: HDR type: %s" %(hdrType), level=xbmc.LOGINFO)
+        self.changeRefreshRate(xbmc.getInfoLabel('Player.Process(VideoFps)'), hdrType)
     
     def onAVChange(self):
         xbmc.log("[RRSwitcher]: Playback changed" , level=xbmc.LOGINFO)
-        self.changeRefreshRate(xbmc.getInfoLabel('Player.Process(VideoFps)'))
+        hdrType = xbmc.getInfoLabel('VideoPlayer.HdrType')
+        if hdrType:
+            xbmc.log("[RRSwitcher]: HDR type: %s" %(hdrType), level=xbmc.LOGINFO)
+        self.changeRefreshRate(xbmc.getInfoLabel('Player.Process(VideoFps)'), hdrType)
 
     def onPlayBackEnded(self):
         self.onPlayBackEndedOrStopped()
@@ -25,18 +31,21 @@ class rrsPlayer(xbmc.Player):
         xbmc.log("[RRSwitcher]: Playback stopped" , level=xbmc.LOGINFO)
         self.changeRefreshRate(rrsconfig.defaultRefreshRate)
 
-    def changeRefreshRate(self, refreshRate):
+    def changeRefreshRate(self, refreshRate, HDR=None):
         if(float(refreshRate) != rrsconfig.currentRefreshRate):
             rrsconfig.currentRefreshRate = float(refreshRate)
             primary = ""
             additionalStr = ""
+            hdrStr = ""
 
             if(rrsconfig.isPrimaryMonitor):
                 primary = "--primary"
             if(rrsconfig.additionalConfig.strip()):
                 additionalStr = rrsconfig.additionalConfig
+            if(rrsconfig.enableHDR and HDR):
+                hdrStr = "--color-mode bt2100"
             
             xbmc.log("[RRSwitcher]: Changing refresh rate to: %s" % rrsconfig.getCurrentRefreshRate() , level=xbmc.LOGINFO)
-            gdctlStr = 'gdctl set --logical-monitor %s --monitor=%s --mode=%s@%s %s' % (primary, rrsconfig.defautlMonitorName, rrsconfig.defaultResolution, rrsconfig.getCurrentRefreshRate(), additionalStr)
+            gdctlStr = '%s set --logical-monitor %s --monitor=%s --mode=%s@%s %s %s' % (rrsconfig.gdctlPath, primary, rrsconfig.defautlMonitorName, rrsconfig.defaultResolution, rrsconfig.getCurrentRefreshRate(), additionalStr, hdrStr)
             xbmc.log("[RRSwitcher]: Gdctl String: %s" % gdctlStr, level=xbmc.LOGINFO)
             os.system(gdctlStr)


### PR DESCRIPTION
Change the "gdctl" command into a configurable string. This is useful for flatpak users, who need to call /run/host/bin/gdctl instead of just gdctl, and anybody else with a non-standard system configuration.

Add optional HDR support by detecting if we are playing HDR content, and if so we add "--color-mode bt2100" to the gdctl command.

Also some expansion of the README file, with some hints for Kodi flatpak users.